### PR TITLE
Update structuredefinition-profile-smokingstatus.json

### DIFF
--- a/input/resources/structuredefinition-profile-smokingstatus.json
+++ b/input/resources/structuredefinition-profile-smokingstatus.json
@@ -3,11 +3,11 @@
   "id": "profile-smokingstatus",
   "url": "http://hl7.org/fhir/ca/baseline/StructureDefinition/profile-smokingstatus",
   "version": "0.0.0",
-  "name": "SmokingStatusProfile",
-  "title": "Smoking Status Profile",
+  "name": "ObservationSmokingStatusProfile",
+  "title": "Observation (Tobacco Smoking Status) Profile",
   "status": "draft",
   "publisher": "HL7 Canada",
-  "description": "Proposed constraints and extensions on the Observation Resource to support collection of smoking status information.  Generated as a first step toward creating a set of Canadian Baseline FHIR profiles.",
+  "description": "Proposed constraints and extensions on the Observation Resource to support collection of tobacco smoking status information.  Generated as a first step toward creating a set of Canadian Baseline FHIR profiles.",
   "kind": "resource",
   "abstract": false,
   "type": "Observation",
@@ -19,12 +19,11 @@
         "id": "Observation",
         "path": "Observation",
         "short": "Smoking Status Profile",
-        "definition": "The Smoking Status Profile is based upon the core FHIR Observation Resource"
+        "definition": "The Observation (Tobacco Smoking Status) Profile is based upon the core FHIR Observation Resource"
       },
       {
         "id": "Observation.status",
         "path": "Observation.status",
-        "mustSupport": true,
         "binding": {
           "strength": "required",
           "valueSet": "http://hl7.org/fhir/ValueSet/observation-status"


### PR DESCRIPTION
Changed name of profile to be more clear about scope and relaxed the MS flag on observation.status in accordance with the changes requested in issue # 1514 from DDR against the IPS smoking status profile