### PR TITLE
Resolution of Issue #2365

### DIFF
--- a/input/pagecontent/StructureDefinition-profile-practitioner-registry-intro.md
+++ b/input/pagecontent/StructureDefinition-profile-practitioner-registry-intro.md
@@ -5,6 +5,13 @@
     <br>
     <br>
     The CA Baseline is asking other jurisdictions or implementers to provide feedback if other values are being used for identifier.type not already discussed in this profile</p>
+		<p> For Practitioner.qualification, slicing has been maintained to demonstrate that there are some registries supporting hybridized registry/eReferral use cases that utilize a different code system (HealthcareProviderRoleType) from the QualifiedRoleType that was incorporated by many HL7 V3 implementations. This separation based on use case and age of implementation remains a challenge in the Canadian ecosystem, and has persisted in part due to the challenges some registry assets face in consuming the longer character lengths present in the SNOMED CT CA HealthcareProviderRoleType value set. Until practices are more standardized or a resolution is in place regarding the disparate use of these two code systems, implementers are cautioned that the CA Baseline's use of these code systems and value sets still may change.
+		<br>
+		<br>
+		The CA Baseline is asking implementers to provide feedback on the value sets and code systems they are expecting to utilize as they transition to FHIR .</p>
+
+		<br>
+		Feedback can be provided through the <a href="https://simplifier.net/CanadianFHIRBaselineProfilesCA-Core/ObservationProfileLaboratory/~issues">Simplifier issue log for this profile</a>.
 	</blockquote>
   </div>
 
@@ -49,7 +56,7 @@ This Practitioner profile contains optional [deceased extension](http://hl7.org/
 
 This extension was previously labeled as a modifier extension (because of its potential impacts on clinical processes if the practitioner is marked deceased), but was removed after further discussion on the nuances of making something a modifierExtension vs regular extension if it was expected to be picked up by registry implementation guides that collect deceased practitioner information but may or may not use it in ways that would align to HL7 FHIR R4 [definition](https://www.hl7.org/fhir/R4/backboneelement-definitions.html#BackboneElement.modifierExtension) and expectations for modifierExtension.
 
-Implementers should recognize that the determination of whether this should be considered a modifierExtension is ongoing. Since Modifier Extensions should have extreme caution in their application and are further nuanced by the use cases in the implementing registry systems, this extension has been shifted back to a regular extension to align to use in existing implementations. Implementers who are considering using this extension in their guidance are required to review the [FHIR Guidance on Modifier Extensions])(https://www.hl7.org/fhir/R4/extensibility.html#modifierExtension) before including this extension in their profile. Implementers should also be aware of the Practitioner.deceased[x] R5 concept and that the CA Baseline is monitoring changes in the element to determine if the approach to this extension requires a shift.
+Implementers should recognize that the determination of whether this should be considered a modifierExtension is ongoing. Since Modifier Extensions should have extreme caution in their application and are further nuanced by the use cases in the implementing registry systems, this extension has been shifted back to a regular extension to align to use in existing implementations. Implementers who are considering using this extension in their guidance might consider applying a Must Support flag on the extension, but those treating wanting to re-create it as a modifier extension are required to review the [FHIR Guidance on Modifier Extensions])(https://www.hl7.org/fhir/R4/extensibility.html#modifierExtension) before including this extension in their profile.  Implementers should also be aware of the Practitioner.deceased[x] R5 concept and that the CA Baseline is monitoring changes in the element to determine if the approach to this extension requires a shift.
 
 ## Usage Note
 This Practitioner profile is intended to provide a foundation for a central or distributed Provider or Healthcare Directory. Additional work flow components and elements may be required for a particular implementation.

--- a/input/resources/structuredefinition-profile-practitioner-registry.json
+++ b/input/resources/structuredefinition-profile-practitioner-registry.json
@@ -3290,7 +3290,8 @@
         "id": "Practitioner",
         "path": "Practitioner",
         "short": "Practitioner Profile",
-        "definition": "The Practitioner Profile is based upon the CA Core FHIR Practitioner Profile for general use"
+        "definition": "The Practitioner Profile is based upon the CA Bas+
+        `eline FHIR Practitioner Profile for general use"
       },
       {
         "id": "Practitioner.extension",
@@ -3393,6 +3394,11 @@
         "mustSupport": true
       },
       {
+        "id": "Practitioner.qualification",
+        "path": "Practitioner.qualification",
+        "comment": "Slicing has been maintained to demonstrate that there are some registries supporting hybridized registry/eReferral use cases that require a separate set of codes. Until practices are more standardized regarding these two code systems, implementers are cautioned that these code systems and value sets still may change. Implementers are encouraged to provide feedback on the value sets and code systems they are expecting to utilize."
+      },
+      {
         "id": "Practitioner.qualification.code.coding",
         "path": "Practitioner.qualification.code.coding",
         "slicing": {
@@ -3425,41 +3431,22 @@
         "path": "Practitioner.qualification.code.coding.system",
         "short": "QualifiedRoleType",
         "definition": "A code system for the degree or educational rank that the credential specifies. May also apply to an Expertise type.",
-        "comment": "The binding strength of this element is [Preferred](https://www.hl7.org/fhir/terminologies.html#strength), meaning that codes are encouraged to draw from the QualifiedRoleType code system for interoperability purposes but are not required to do so to be considered conformant.",
         "min": 1,
-        "binding": {
-          "strength": "preferred",
-          "description": "A code system for the degree or educational rank that the credential specifies",
-          "valueSet": "https://fhir.infoway-inforoute.ca/ValueSet/qualifiedroletype"
-        }
-      },
-      {
-        "id": "Practitioner.qualification.code.coding:Registry.code",
-        "path": "Practitioner.qualification.code.coding.code",
-        "min": 1
+        "fixedString": "https://fhir.infoway-inforoute.ca/CodeSystem/scpqual"
       },
       {
         "id": "Practitioner.qualification.code.coding:eReferral",
         "path": "Practitioner.qualification.code.coding",
-        "sliceName": "eReferral"
+        "sliceName": "eReferral",
+        "comment": "Some registries may be used to support electronic referral use cases. A separate code system for practitioner qualification codes has been identified as in use by at least one Canadian regsitry supporting the hybridized use case."
       },
       {
         "id": "Practitioner.qualification.code.coding:eReferral.system",
         "path": "Practitioner.qualification.code.coding.system",
         "short": "HealthcareProviderRoleType",
         "definition": "A role type that is used to categorize an entity that delivers health care in an expected and professional manner to an entity in need of health care services.",
-        "comment": "The binding strength of this element is [Preferred](https://www.hl7.org/fhir/terminologies.html#strength), meaning that codes are encouraged to draw from the HealthcareProviderRoleType code system for interoperability purposes but are not required to do so to be considered conformant.",
         "min": 1,
-        "binding": {
-          "strength": "preferred",
-          "description": "A code system that is used to categorize an entity that delivers health care",
-          "valueSet": "https://fhir.infoway-inforoute.ca/ValueSet/qualifiedroletype"
-        }
-      },
-      {
-        "id": "Practitioner.qualification.code.coding:eReferral.code",
-        "path": "Practitioner.qualification.code.coding.code",
-        "min": 1
+        "fixedString": "https://fhir.infoway-inforoute.ca/CodeSystem/scptype"
       }
     ]
   }

--- a/input/resources/structuredefinition-profile-practitioner.json
+++ b/input/resources/structuredefinition-profile-practitioner.json
@@ -2534,9 +2534,8 @@
         ]
       },
       {
-        "id": "Practitioner.qualification.code.coding.system",
-        "path": "Practitioner.qualification.code.coding.system",
-        "short": "QualifiedRoleType",
+        "id": "Practitioner.qualification",
+        "path": "Practitioner.qualification",
         "definition": "A code system for the degree or educational rank that the credential specifies. May also apply to an Expertise type.",
         "comment": "The binding strength of this element is [Preferred](https://www.hl7.org/fhir/terminologies.html#strength), meaning that codes are encouraged to draw from the QualifiedRoleType code system for interoperability purposes but are not required to do so to be considered conformant.",
         "binding": {


### PR DESCRIPTION
Discussion on 8/19/22 to resolve 2 technical issues present in the slicing of practitioner.qualification - a value set had incorrectly been copied into both slices (though the intent was to maintain separation based on code system), and a value set was used in both rather than a code system in the slices. The original code systems were input and an STU note was added to summarize discussion.