### PR TITLE
issue #1327

### DIFF
--- a/input/resources/structuredefinition-profile-medication.json
+++ b/input/resources/structuredefinition-profile-medication.json
@@ -178,13 +178,19 @@
         }
       },
       {
-        "id": "Medication.code.extension:isRepresentative",
-        "path": "Medication.code.extension",
+        "id": "Medication.code.coding",
+        "path": "Medication.code.coding",
+        "comment": "CA Baseline Usage Notes: either text or at least one coding or both have to be present",
+        "mustSupport": true
+      },
+      {
+        "id": "Medication.code.coding.extension:isRepresentative",
+        "path": "Medication.code.coding.extension",
         "sliceName": "isRepresentative",
         "short": "Socialized Optional Extension: Code is Representative",
         "definition": "If set to true, indicates that the medication code sent was chosen as a representative code of a drug picked at a more general level. I.e. The user didn't actually choose this specific code. The intended constraints around what drug should be supplied are conveyed by the request's substitution rules.",
         "min": 0,
-        "max": "1",
+        "max": 1,
         "type": [
           {
             "code": "Extension",
@@ -194,12 +200,6 @@
           }
         ],
         "mustSupport": false
-      },
-      {
-        "id": "Medication.code.coding",
-        "path": "Medication.code.coding",
-        "comment": "CA Baseline Usage Notes: either text or at least one coding or both have to be present",
-        "mustSupport": true
       },
       {
         "id": "Medication.code.coding.system",


### PR DESCRIPTION
updated medication.code.extension:isRepresentative to apply to medication.code.coding instead. also, fixed assumed typo in max limiter from string 1 to integer 1