### PR TITLE
#2481 has typo in pagecontent as well as resource extension

### DIFF
--- a/input/pagecontent/StructureDefinition-ext-servicelanguage-intro.md
+++ b/input/pagecontent/StructureDefinition-ext-servicelanguage-intro.md
@@ -1,5 +1,5 @@
 <!--- Text entered into this file will appear at the top of the profiles page before the Formal Views of the profile content. -->
 
-Indentifies a language that is used to services are provide services at a Location or Organization.
+Identifies a language that is used to services are provide services at a Location or Organization.
 
 **Note** this extension was created to meet the requirement of [ext-location-language](https://simplifier.net/ProvincialProviderRe/organizationLanguage) extension used in the ON PPR guide which is semantically different than Resource.language.  The implementation is different, with the intent of being more consistent with the Communication element on the Patient and Practitioner resources.


### PR DESCRIPTION
After reviewing the page generated after the previous typo fix, I noticed that the page content markdown also has "indentifies", so I fixed that as well.