### PR TITLE
Update structuredefinition-profile-diagnosticreport.json

### DIFF
--- a/input/resources/structuredefinition-profile-diagnosticreport.json
+++ b/input/resources/structuredefinition-profile-diagnosticreport.json
@@ -313,7 +313,7 @@
         "path": "DiagnosticReport.result",
         "sliceName": "LabResult",
         "comment": "Observations that represent results produced by laboratory tests or panels/studies",
-        "min": 1,
+        "min": 0,
         "max": "*",
         "type": [
           {


### PR DESCRIPTION
As per community issue #2500, reduced the minimum cardinality of DiagnosticReport.result꞉LabResult from 1 to 0.