### PR TITLE
Update structuredefinition-profile-medication.json

### DIFF
--- a/input/resources/structuredefinition-profile-medication.json
+++ b/input/resources/structuredefinition-profile-medication.json
@@ -111,7 +111,7 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "https://fhir.infoway-inforoute.ca/ValueSet/CA-HC-DIN"
+                  "system": "http://hl7.org/fhir/NamingSystem/ca-hc-din"
                 }
               ]
             }
@@ -121,7 +121,7 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "https://fhir.infoway-inforoute.ca/ValueSet/CA-HC-NPN"
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-hc-npn"
                 }
               ]
             }
@@ -131,7 +131,7 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "https://fhir.infoway-inforoute.ca/ValueSet/prescriptionmedicinalproduct"
+                  "system": "http://terminology.hl7.org/CodeSystem/hc-CCDD"
                 }
               ]
             }
@@ -141,7 +141,7 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "http://hl7.org/fhir/uv/ips/ValueSet/medication-snomed-uv-ips"
+                  "system": "http://snomed.info/sct"
                 }
               ]
             }
@@ -151,7 +151,7 @@
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "system": "http://hl7.org/fhir/uv/ips/ValueSet/whoatc-uv-ips"
+                  "system": "http://www.whocc.no/atc"
                 }
               ]
             }


### PR DESCRIPTION
Issue #1885 - Medication.code examples use value sets instead of code systems (see https://simplifier.net/cabaseline/medicationprofile/~issues/1885) 

Updated examples to use CodeSystems instead of ValueSets.

@sheridancook 
@ElliotSilver 