### PR TITLE
Add DeepWiki badge and link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # ca-baseline
+
+[![DeepWiki](https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2FHL7-Canada%2Fca-baseline)](https://deepwiki.com/HL7-Canada/ca-baseline)
  
 ### Canadian Baseline Implementation Guide
 
@@ -19,6 +21,8 @@ This guide is a **living document** that includes notes and profiles that contin
 For information on where we are at in the working group review follow our progress in the [Infocentral FHIR Implementation Working Group page](https://infocentral.infoway-inforoute.ca/en/collaboration/wg/fhir-implementations)
 
 The [CI build for this guide can be found here](https://build.fhir.org/ig/HL7-Canada/ca-baseline/index.html).
+
+The [DeepWiki page for this guide can be found here](https://deepwiki.com/HL7-Canada/ca-baseline).
 
 ### Principles
 


### PR DESCRIPTION
This pull request adds references to DeepWiki in the `README.md` file to provide additional resources related to the Canadian Baseline Implementation Guide.

Addition of DeepWiki references:

* Added a DeepWiki badge at the top of the `README.md` to visually indicate the project's presence on DeepWiki.
* Added a link to the DeepWiki page for this guide in the information section for further documentation and collaboration.